### PR TITLE
Address `itemCount` related bugs

### DIFF
--- a/includes/block.php
+++ b/includes/block.php
@@ -95,10 +95,10 @@ function render_block( $attributes ) {
 	$post_type = explode( ',', $attributes['customPostType'] );
 
 	$args = array(
-		'post_type' => $post_type[0],
-		'per_page'  => absint( $attributes['itemCount'] ),
-		'order'     => $attributes['order'],
-		'orderby'   => $attributes['orderBy'],
+		'post_type'       => $post_type[0],
+		'posts_per_page'  => absint( $attributes['itemCount'] ),
+		'order'           => $attributes['order'],
+		'orderby'         => $attributes['orderBy'],
 	);
 
 	if ( '' !== $attributes['customTaxonomy'] && 0 < $attributes['termID'] ) {

--- a/src/index.js
+++ b/src/index.js
@@ -391,8 +391,8 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 						<TextControl
 							label="Number of items"
 							value={ itemCount }
-							onChange={ ( itemCount ) => {
-								setAttributes( { itemCount } );
+							onChange={ ( value ) => {
+								setAttributes( { itemCount: Number( value ) } );
 								setState( { triggerRefresh: true, latestPosts: [] } );
 							} }
 						/>


### PR DESCRIPTION
* The `itemCount` attribute was being added to the block as a `string` even though the block was validating an `integer`. This saves it as an `integer` so that it sticks around.
* The rendering of the block used the wrong argument for `get_posts()` to specify the number of results, so the default number of results was always returned.