### PR TITLE
Extend taxonomy options

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -1,14 +1,9 @@
-.happyprime-block-latest-custom-posts_taxonomy-setting:not(:only-child) {
+.happyprime-block-latest-custom-posts_taxonomy-setting-wrapper:not(:only-child) {
 	border-bottom: 1px solid #e2e4e7;
-	padding: 0px 0 12px 32px;
 	position: relative;
 }
 
-.happyprime-block-latest-custom-posts_taxonomy-setting:not(:first-of-type) {
-	padding-top: 16px;
-}
-
-.happyprime-block-latest-custom-posts_taxonomy-setting:not(:only-child) .components-base-control {
+.happyprime-block-latest-custom-posts_taxonomy-setting-wrapper:not(:only-child) .components-base-control {
 	margin-bottom: 0;
 }
 
@@ -20,6 +15,18 @@
 	top: 15px;
 }
 
+.happyprime-block-latest-custom-posts_taxonomy-setting-wrapper:not(:only-child) .happyprime-block-latest-custom-posts_taxonomy-setting {
+	padding: 0px 16px 12px 32px;
+}
+
+.happyprime-block-latest-custom-posts_taxonomy-setting-wrapper:not(:first-of-type) .happyprime-block-latest-custom-posts_taxonomy-setting {
+	padding-top: 16px;
+}
+
 .happyprime-block-latest-custom-posts_taxonomy .components-base-control.components-radio-control {
 	padding: 16px 0 0 32px;
+}
+
+.happyprime-block-latest-custom-posts_taxonomy-setting-wrapper button:hover ~ div {
+	background: #e2e4e7;
 }

--- a/css/editor.css
+++ b/css/editor.css
@@ -1,3 +1,7 @@
+.happyprime-block-latest-custom-posts_taxonomy {
+	margin-bottom: 24px;
+}
+
 .happyprime-block-latest-custom-posts_taxonomy-setting-wrapper:not(:only-child) {
 	border-bottom: 1px solid #e2e4e7;
 	position: relative;

--- a/css/editor.css
+++ b/css/editor.css
@@ -1,0 +1,17 @@
+.happyprime-block-latest-custom-posts_taxonomy-setting:not(:only-child) {
+	border-bottom: 1px solid #e2e4e7;
+	padding: 20px 0 16px 20px;
+	position: relative;
+}
+
+.happyprime-block-latest-custom-posts_taxonomy-setting:not(:only-child) .components-base-control {
+	margin-bottom: 0;
+}
+
+.happyprime-block-latest-custom-posts_remove-taxonomy-setting {
+	border-radius: 50%;
+	left: 0;
+	padding: 0;
+	position: absolute;
+	top: 0;
+}

--- a/css/editor.css
+++ b/css/editor.css
@@ -1,7 +1,11 @@
 .happyprime-block-latest-custom-posts_taxonomy-setting:not(:only-child) {
 	border-bottom: 1px solid #e2e4e7;
-	padding: 20px 0 16px 20px;
+	padding: 0px 0 12px 32px;
 	position: relative;
+}
+
+.happyprime-block-latest-custom-posts_taxonomy-setting:not(:first-of-type) {
+	padding-top: 16px;
 }
 
 .happyprime-block-latest-custom-posts_taxonomy-setting:not(:only-child) .components-base-control {
@@ -10,8 +14,12 @@
 
 .happyprime-block-latest-custom-posts_remove-taxonomy-setting {
 	border-radius: 50%;
-	left: 0;
+	left: 6px;
 	padding: 0;
 	position: absolute;
-	top: 0;
+	top: 15px;
+}
+
+.happyprime-block-latest-custom-posts_taxonomy .components-base-control.components-radio-control {
+	padding: 16px 0 0 32px;
 }

--- a/css/editor.css
+++ b/css/editor.css
@@ -23,7 +23,7 @@
 	padding-top: 16px;
 }
 
-.happyprime-block-latest-custom-posts_taxonomy .components-base-control.components-radio-control {
+.happyprime-block-latest-custom-posts_taxonomy > .components-base-control.components-radio-control {
 	padding: 16px 0 0 32px;
 }
 

--- a/css/editor.css
+++ b/css/editor.css
@@ -34,3 +34,7 @@
 .happyprime-block-latest-custom-posts_taxonomy-setting-wrapper button:hover ~ div {
 	background: #e2e4e7;
 }
+
+.happyprime-block-latest-custom-posts_error .components-spinner {
+	float: none;
+}

--- a/includes/block.php
+++ b/includes/block.php
@@ -200,4 +200,13 @@ function enqueue_block_editor_assets() {
 		block_version(),
 		true
 	);
+
+	wp_enqueue_style(
+		'hp-latest-custom-posts',
+		plugins_url( 'css/editor.css', __DIR__ ),
+		array(
+			'wp-edit-blocks',
+		),
+		block_version()
+	);
 }

--- a/includes/block.php
+++ b/includes/block.php
@@ -10,6 +10,7 @@ namespace HappyPrime\LatestCustomPosts\Block;
 
 add_action( 'init', __NAMESPACE__ . '\\register_block' );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets' );
+add_action( 'rest_api_init', __NAMESPACE__ . '\\register_route' );
 
 /**
  * Provide a block version number for scripts.
@@ -21,7 +22,7 @@ function block_version() {
 }
 
 /**
- * Registers the `core/latest-posts` block on server.
+ * Registers the `happyprime/latest-custom-posts` block on server.
  */
 function register_block() {
 	register_block_type(
@@ -71,28 +72,9 @@ function register_block() {
 }
 
 /**
- * Renders block in PHP.
  *
- * @param array $attributes The block attributes.
- *
- * @return string HTML
  */
-function render_block( $attributes ) {
-	$defaults   = array(
-		'customPostType'  => 'post,posts',
-		'customTaxonomy'  => array(),
-		'taxRelation'     => '',
-		'termID'          => 0,
-		'itemCount'       => 3,
-		'order'           => 'desc',
-		'orderBy'         => 'date',
-		'displayPostDate' => false,
-		'postLayout'      => 'list',
-		'columns'         => 2,
-		'className'       => '',
-	);
-	$attributes = wp_parse_args( $attributes, $defaults );
-
+function build_query_args( $attributes ) {
 	$post_type = explode( ',', $attributes['customPostType'] );
 
 	$args = array(
@@ -128,7 +110,32 @@ function render_block( $attributes ) {
 		$args['tax_query'] = $tax_query; // phpcs:ignore
 	}
 
-	$posts = get_posts( $args );
+	return $args;
+}
+
+/**
+ * Renders block in PHP.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string HTML
+ */
+function render_block( $attributes ) {
+	$defaults   = array(
+		'customPostType'  => 'post,posts',
+		'customTaxonomy'  => array(),
+		'taxRelation'     => '',
+		'itemCount'       => 3,
+		'order'           => 'desc',
+		'orderBy'         => 'date',
+		'displayPostDate' => false,
+		'postLayout'      => 'list',
+		'columns'         => 2,
+		'className'       => '',
+	);
+	$attributes = wp_parse_args( $attributes, $defaults );
+	$args       = build_query_args( $attributes );
+	$posts      = get_posts( $args );
 
 	// Render nothing if no posts are available.
 	if ( empty( $posts ) ) {
@@ -138,6 +145,7 @@ function render_block( $attributes ) {
 	ob_start();
 
 	$container_class = 'wp-block-latest-posts wp-block-latest-posts__list happyprime-latest-custom-posts';
+
 	if ( isset( $attributes['align'] ) ) {
 		$container_class .= ' align' . $attributes['align'];
 	}
@@ -209,4 +217,58 @@ function enqueue_block_editor_assets() {
 		),
 		block_version()
 	);
+}
+
+/**
+ * Register a REST API route for this block.
+ */
+function register_route() {
+	register_rest_route(
+		'lcp/v1',
+		'posts',
+		array(
+			'methods'  => 'GET',
+			'callback' => __NAMESPACE__ . '\rest_response',
+		)
+	);
+}
+
+/**
+ * Return posts based on the provided parameters.
+ *
+ * @param \WP_Request $request The incoming REST API request object.
+ *
+ * @return array Posts found using the provided parameters.
+ */
+function rest_response( $request ) {
+	$attributes = array(
+		'customPostType'  => $request->get_param( 'post_type' ) ? $request->get_param( 'post_type' ) : 'post,posts',
+		'customTaxonomy'  => $request->get_param( 'taxonomies' ) ? $request->get_param( 'taxonomies' ) : array(),
+		'taxRelation'     => $request->get_param( 'tax_relation' ) ? $request->get_param( 'tax_relation' ) : '',
+		'itemCount'       => $request->get_param( 'per_page' ) ? $request->get_param( 'per_page' ) : 3,
+		'order'           => $request->get_param( 'order' ) ? $request->get_param( 'order' ) : 'desc',
+		'orderBy'         => $request->get_param( 'order_by' ) ? $request->get_param( 'order_by' ) : 'date',
+	);
+	$args       = build_query_args( $attributes );
+	$query      = new \WP_Query( $args );
+
+	// Assume no posts match the criteria by default.
+	$posts = array();
+
+	if ( $query->have_posts() ) {
+		while ( $query->have_posts() ) {
+			$query->the_post();
+
+			$post = array(
+				'title'    => get_the_title(),
+				'date_gmt' => get_the_date( '' ),
+				'link'     => get_the_permalink(),
+			);
+
+			$posts[] = $post;
+		}
+		wp_reset_postdata();
+	}
+
+	return $posts;
 }

--- a/includes/block.php
+++ b/includes/block.php
@@ -94,7 +94,7 @@ function build_query_args( $attributes ) {
 
 	// If this is a previous version of the block, overwrite
 	// the `customTaxonomy` attribute using the new format.
-	if ( $attributes['termID'] ) {
+	if ( $attributes['termID'] && ! is_array( $attributes['customTaxonomy'] ) ) {
 		$attributes['customTaxonomy'] = array(
 			array(
 				'slug'  => $attributes['customTaxonomy'],

--- a/includes/block.php
+++ b/includes/block.php
@@ -36,7 +36,7 @@ function register_block() {
 					'type'    => 'array',
 					'default' => array(),
 				),
-				'customTaxRel'  => array(
+				'taxRelation'     => array(
 					'type'    => 'string',
 					'default' => '',
 				),
@@ -81,7 +81,7 @@ function render_block( $attributes ) {
 	$defaults   = array(
 		'customPostType'  => 'post,posts',
 		'customTaxonomy'  => array(),
-		'customTaxRel'    => '',
+		'taxRelation'     => '',
 		'termID'          => 0,
 		'itemCount'       => 3,
 		'order'           => 'desc',
@@ -105,8 +105,8 @@ function render_block( $attributes ) {
 	if ( ! empty( $attributes['customTaxonomy'] ) ) {
 		$tax_query = array();
 
-		if ( '' !== $attributes['customTaxRel'] ) {
-			$tax_query['relation'] = $attributes['customTaxRel'];
+		if ( '' !== $attributes['taxRelation'] ) {
+			$tax_query['relation'] = $attributes['taxRelation'];
 		}
 
 		foreach ( $attributes['customTaxonomy'] as $taxonomy ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3869,10 +3869,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -7085,9 +7088,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.escape": {
@@ -7562,9 +7565,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -9596,9 +9599,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -10892,38 +10895,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {

--- a/src/index.js
+++ b/src/index.js
@@ -505,34 +505,36 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 								} );
 							} }
 						/>
-						{ ( customPostType !== '' ) && (
-							<div className="happyprime-block-latest-custom-posts_taxonomy">
-								{ ( 1 < customTaxonomy.length ) && (
-									<p>{ __( 'Taxonomy Settings' ) }</p>
-								) }
-								<div className="happyprime-block-latest-custom-posts_taxonomy-settings">
-									{ ( 0 < customTaxonomy.length ) && customTaxonomy.map( ( taxonomy, index ) => taxonomySetting( taxonomy, index ) ) }
-								</div>
-								{ ( 1 < customTaxonomy.length ) && (
-									<RadioControl
-										label={ __( 'Relation' ) }
-										selected={ taxRelation }
-										options={ [
-											{ label: __( 'And' ), value: 'AND' },
-											{ label: __( 'Or' ), value: 'OR' },
-										] }
-										onChange={ ( option ) => { setAttributes( { taxRelation: option } ) } }
-									/>
-								) }
-								{ ( 0 < customTaxonomy.length && 0 < customTaxonomy[0].terms.length ) && (
-									<IconButton
-										icon="plus-alt"
-										label={ __( 'Add more taxonomy settings' ) }
-										onClick={ () => setAttributes( { customTaxonomy: customTaxonomy.concat( TAXONOMY_SETTING ) } ) }
-									>{ __( 'Add more taxonomy settings' ) }</IconButton>
+						<div className="happyprime-block-latest-custom-posts_taxonomy">
+							{ ( 1 < customTaxonomy.length ) && (
+								<p>{ __( 'Taxonomy Settings' ) }</p>
+							) }
+							<div className="happyprime-block-latest-custom-posts_taxonomy-settings">
+								{ ( customTaxonomy && 0 < customTaxonomy.length ) ? (
+									customTaxonomy.map( ( taxonomy, index ) => taxonomySetting( taxonomy, index ) )
+								) : (
+									taxonomySetting( TAXONOMY_SETTING, 0 )
 								) }
 							</div>
-						) }
+							{ ( 1 < customTaxonomy.length ) && (
+								<RadioControl
+									label={ __( 'Relation' ) }
+									selected={ taxRelation }
+									options={ [
+										{ label: __( 'And' ), value: 'AND' },
+										{ label: __( 'Or' ), value: 'OR' },
+									] }
+									onChange={ ( option ) => { setAttributes( { taxRelation: option } ) } }
+								/>
+							) }
+							{ ( customTaxonomy && 0 < customTaxonomy.length && customTaxonomy[0].terms && 0 < customTaxonomy[0].terms.length ) && (
+								<IconButton
+									icon="plus-alt"
+									label={ __( 'Add more taxonomy settings' ) }
+									onClick={ () => setAttributes( { customTaxonomy: customTaxonomy.concat( TAXONOMY_SETTING ) } ) }
+								>{ __( 'Add more taxonomy settings' ) }</IconButton>
+							) }
+						</div>
 						{ postLayout === 'grid' &&
 							<RangeControl
 								label={ __( 'Columns' ) }

--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,8 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 					triggerTermsRefresh: false,
 				} );
 
+				let terms = [];
+
 				customTaxonomy.forEach( ( taxonomy, index ) => {
 
 					const restSlug = taxonomy.slug.split( ',' )[1];
@@ -189,13 +191,16 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							}
 						} );
 
-						setState( { taxonomyTerms: Object.assign( taxonomyTerms, { [ index ]: termData } ) } );
+						Object.assign( terms, { [ index ]: termData } );
 					} ).catch( error => {
 						setState( { errorMessage: error.message } );
 					} );
 				} );
 
-				setState( { doingTermsFetch: false } );
+				setState( {
+					taxonomyTerms: terms,
+					doingTermsFetch: false,
+				} );
 			}
 
 			if ( postID && '' !== customPostType && doRequest ) {

--- a/src/index.js
+++ b/src/index.js
@@ -233,7 +233,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 			columns,
 		} = attributes;
 
-		const customTaxonomy = ( 'string' !== typeof attributes.customTaxonomy )
+		const customTaxonomy = ( 'string' !== typeof attributes.customTaxonomy && !attributes.termID )
 			? attributes.customTaxonomy
 			: [ {
 				slug: attributes.customTaxonomy,

--- a/src/index.js
+++ b/src/index.js
@@ -435,6 +435,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							<SelectControl
 								multiple
 								label="Term(s)"
+								help="Cmd or Ctrl + click to select multiple terms"
 								value={ taxonomy.terms }
 								options={ terms[ index ] }
 								onChange={ ( value ) => {

--- a/src/index.js
+++ b/src/index.js
@@ -403,11 +403,18 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							icon="dismiss"
 							label={ __( 'Remove taxonomy setting' ) }
 							onClick={ () => {
-								if ( 1 === index && 2 === customTaxonomy.length ) {
-									setAttributes( { taxRelation: '' } );
-								}
 								customTaxonomy.splice( index, 1 );
+
 								setAttributes( { customTaxonomy: [ ...customTaxonomy ] } );
+
+								if ( 1 === customTaxonomy.length ) {
+									setAttributes( { taxRelation: undefined } );
+								}
+
+								setState( {
+									triggerRefresh: true,
+									latestPosts: [],
+								} );
 							} }
 						/>
 					) }
@@ -566,7 +573,13 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 								<IconButton
 									icon="plus-alt"
 									label={ __( 'Add more taxonomy settings' ) }
-									onClick={ () => setAttributes( { customTaxonomy: customTaxonomy.concat( TAXONOMY_SETTING ) } ) }
+									onClick={ () => {
+										setAttributes( { customTaxonomy: customTaxonomy.concat( TAXONOMY_SETTING ) } )
+
+										if ( !taxRelation ) {
+											setAttributes( { taxRelation: 'AND' } )
+										}
+									} }
 								>{ __( 'Add more taxonomy settings' ) }</IconButton>
 							) }
 						</div>

--- a/src/index.js
+++ b/src/index.js
@@ -396,52 +396,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 
 		const taxonomySetting = ( taxonomy, index ) => {
 			return (
-				<div className="happyprime-block-latest-custom-posts_taxonomy-setting">
-					<SelectControl
-						label="Taxonomy"
-						value={ ( taxonomy.slug ) ? taxonomy.slug : 'none' }
-						options={ taxonomyOptions }
-						onChange={ ( value ) => {
-							setAttributes( { customTaxonomy: updatedCustomTaxonomy( index, 'slug', value ) } );
-							setState( {
-								triggerTermsRefresh: true,
-								taxonomyTerms: Object.assign( terms, { [ index ]: [] } ),
-							} );
-						} }
-					/>
-					{ ( taxonomy.slug !== '' && terms[ index ] && 0 < terms[ index ].length ) && (
-						<SelectControl
-							multiple
-							label="Term(s)"
-							value={ taxonomy.terms }
-							options={ terms[ index ] }
-							onChange={ ( value ) => {
-								setAttributes( { customTaxonomy: updatedCustomTaxonomy( index, 'terms', value ) } );
-								setState( {
-									triggerRefresh: true,
-									latestPosts: [],
-								} );
-							} }
-						/>
-					) }
-					{ ( taxonomy.terms && 1 < taxonomy.terms.length ) && (
-						<RadioControl
-							value={ taxonomy.operator }
-							label="Show posts with:"
-							selected={ taxonomy.operator }
-							options={ [
-								{ label: 'Any selected terms', value: 'IN' },
-								{ label: 'All selected terms', value: 'AND' },
-							] }
-							onChange={ ( value ) => {
-								setAttributes( { customTaxonomy: updatedCustomTaxonomy( index, 'operator', value ) } );
-								setState( {
-									triggerRefresh: true,
-									latestPosts: [],
-								} );
-							} }
-						/>
-					) }
+				<div className="happyprime-block-latest-custom-posts_taxonomy-setting-wrapper">
 					{ 0 < index && (
 						<IconButton
 							className="happyprime-block-latest-custom-posts_remove-taxonomy-setting"
@@ -456,6 +411,53 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							} }
 						/>
 					) }
+					<div className="happyprime-block-latest-custom-posts_taxonomy-setting">
+						<SelectControl
+							label="Taxonomy"
+							value={ ( taxonomy.slug ) ? taxonomy.slug : 'none' }
+							options={ taxonomyOptions }
+							onChange={ ( value ) => {
+								setAttributes( { customTaxonomy: updatedCustomTaxonomy( index, 'slug', value ) } );
+								setState( {
+									triggerTermsRefresh: true,
+									taxonomyTerms: Object.assign( terms, { [ index ]: [] } ),
+								} );
+							} }
+						/>
+						{ ( taxonomy.slug !== '' && terms[ index ] && 0 < terms[ index ].length ) && (
+							<SelectControl
+								multiple
+								label="Term(s)"
+								value={ taxonomy.terms }
+								options={ terms[ index ] }
+								onChange={ ( value ) => {
+									setAttributes( { customTaxonomy: updatedCustomTaxonomy( index, 'terms', value ) } );
+									setState( {
+										triggerRefresh: true,
+										latestPosts: [],
+									} );
+								} }
+							/>
+						) }
+						{ ( taxonomy.terms && 1 < taxonomy.terms.length ) && (
+							<RadioControl
+								value={ taxonomy.operator }
+								label="Show posts with:"
+								selected={ taxonomy.operator }
+								options={ [
+									{ label: 'Any selected terms', value: 'IN' },
+									{ label: 'All selected terms', value: 'AND' },
+								] }
+								onChange={ ( value ) => {
+									setAttributes( { customTaxonomy: updatedCustomTaxonomy( index, 'operator', value ) } );
+									setState( {
+										triggerRefresh: true,
+										latestPosts: [],
+									} );
+								} }
+							/>
+						) }
+					</div>
 				</div>
 			);
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -363,7 +363,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 			} );
 
 			// Resets the `terms` and `operator` properties when the slug is changed.
-			if ( 'slug' === property && value !== customTaxonomy[ index ].slug ) {
+			if ( 'slug' === property && customTaxonomy[ index ] && value !== customTaxonomy[ index ].slug ) {
 				customTaxonomyUpdates = Object.values( {
 					...customTaxonomyUpdates,
 					[ index ]: {

--- a/src/index.js
+++ b/src/index.js
@@ -447,7 +447,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							<SelectControl
 								multiple
 								label="Term(s)"
-								help="Cmd or Ctrl + click to select multiple terms"
+								help="Ctrl/Cmd + click to select multiple terms"
 								value={ taxonomy.terms }
 								options={ terms[ index ] }
 								onChange={ ( value ) => {

--- a/src/index.js
+++ b/src/index.js
@@ -218,13 +218,15 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 				const restSlug = customPostType.split( ',' )[1];
 
 				customTaxonomy.forEach( ( taxonomy ) => {
-					const termSlug = taxonomy.slug.split( ',' )[1];
-
-					if ( 0 > taxonomy.terms.length ) {
+					if ( !taxonomy.slug || 0 > taxonomy.terms.length ) {
 						return;
 					}
 
-					if ( 'IN' === taxonomy.operator ) {
+					const termSlug = taxonomy.slug.split( ',' )[1];
+
+					if ( 'AND' === taxonomy.operator ) {
+						// This space intentionally left blank...
+					} else {
 						data[ termSlug ] = taxonomy.terms.join( ',' );
 					}
 				} );
@@ -376,7 +378,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							} );
 						} }
 					/>
-					{ ( taxonomy.slug !== '' && 0 < terms[ index ].length ) && (
+					{ ( taxonomy.slug !== '' && terms[ index ] && 0 < terms[ index ].length ) && (
 						<SelectControl
 							multiple
 							label="Term(s)"
@@ -391,7 +393,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							} }
 						/>
 					) }
-					{ 1 < taxonomy.terms.length && (
+					{ ( taxonomy.terms && 1 < taxonomy.terms.length ) && (
 						<RadioControl
 							value={ taxonomy.operator }
 							label="Show posts with:"

--- a/src/index.js
+++ b/src/index.js
@@ -556,8 +556,9 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							onChange={ ( customPostType ) => {
 								setAttributes( {
 									customPostType,
-									customTaxonomy: [ TAXONOMY_SETTING ],
+									customTaxonomy: [],
 								} );
+
 								setState( {
 									triggerRefresh: true,
 									latestPosts: [],

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ const {
 const {
 	InspectorControls,
 	BlockControls,
-} = wp.editor;
+} = ( 'undefined' === typeof wp.blockEditor ) ? wp.editor : wp.blockEditor;
 
 const {
 	addQueryArgs,
@@ -83,45 +83,6 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 		html: false,
 	},
 
-	attributes: {
-		customPostType: {
-			type: 'string',
-			default: 'post,posts',
-		},
-		customTaxonomy: {
-			type: 'array',
-			default: [],
-		},
-		taxRelation: {
-			type: 'string',
-			default: 'AND',
-		},
-		itemCount: {
-			type: 'integer',
-			default: 3,
-		},
-		order: {
-			type: 'string',
-			default: 'desc',
-		},
-		orderBy: {
-			type: 'string',
-			default: 'date',
-		},
-		displayPostDate: {
-			type: 'boolean',
-			default: false
-		},
-		postLayout: {
-			type: 'string',
-			default: 'list',
-		},
-		columns: {
-			type: 'integer',
-			default: 2,
-		},
-	},
-
 	edit: compose( [
 		withState( {
 			latestPosts: [],
@@ -147,12 +108,18 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 
 			const {
 				customPostType,
-				customTaxonomy,
 				itemCount,
 				taxRelation,
 				order,
 				orderBy,
 			} = props.attributes;
+
+			const customTaxonomy = ( 'string' !== typeof props.attributes.customTaxonomy )
+				? props.attributes.customTaxonomy
+				: [ {
+					slug: props.attributes.customTaxonomy,
+					terms: [ `${props.attributes.termID}` ],
+				} ];
 
 			let postID = select( 'core/editor' ).getCurrentPostId();
 
@@ -258,7 +225,6 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 		const {
 			itemCount,
 			customPostType,
-			customTaxonomy,
 			taxRelation,
 			order,
 			orderBy,
@@ -267,10 +233,17 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 			columns,
 		} = attributes;
 
+		const customTaxonomy = ( 'string' !== typeof attributes.customTaxonomy )
+			? attributes.customTaxonomy
+			: [ {
+				slug: attributes.customTaxonomy,
+				terms: [ `${attributes.termID}` ],
+			} ];
+
 		let displayPosts;
 
 		// Ensure the number of posts is limited to the expected number of posts.
-		if ( posts.length > itemCount ) {
+		if ( posts && posts.length > itemCount ) {
 			displayPosts = posts.slice( 0, itemCount );
 		} else {
 			displayPosts = posts;

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ const {
 	RangeControl,
 	RadioControl,
 	IconButton,
+	Spinner,
 } = wp.components;
 
 const {
@@ -634,7 +635,13 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 						{ displayPosts && displayPosts.map( post => displayListItem( post ) ) }
 					</ul>
 				) : (
-					<p className="happyprime-block-latest-custom-posts_error">{ errorMessage ? errorMessage : 'Select a post type in this block\'s settings.' }</p>
+					<p className="happyprime-block-latest-custom-posts_error">{
+						( errorMessage )
+							? errorMessage
+							: ( customPostType )
+								? <Spinner />
+								: 'Select a post type in this block\'s settings.'
+					}</p>
 				) }
 			</Fragment>
 		);

--- a/src/index.js
+++ b/src/index.js
@@ -172,35 +172,30 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 				} );
 
 				customTaxonomy.forEach( ( taxonomy, index ) => {
+
 					const restSlug = taxonomy.slug.split( ',' )[1];
 
 					if ( undefined === typeof restSlug ) {
-						setState( {
-							doingTermsFetch: false,
-						} );
+						setState( { doingTermsFetch: false } );
 					}
 
 					apiFetch( {
 						path: addQueryArgs( '/wp/v2/' + restSlug, { per_page: 100 } ),
 					} ).then( data => {
-							const termData = data.map( term => {
-								return {
-									label: term.name,
-									value: term.id,
-								}
-							} );
-						setState( {
-							taxonomyTerms: Object.assign( taxonomyTerms, { [ index ]: termData } ),
-							doingTermsFetch: false,
+						const termData = data.map( term => {
+							return {
+								label: term.name,
+								value: term.id,
+							}
 						} );
+
+						setState( { taxonomyTerms: Object.assign( taxonomyTerms, { [ index ]: termData } ) } );
 					} ).catch( error => {
-						setState( {
-							errorMessage: error.message,
-							taxonomyTerms: Object.assign( taxonomyTerms, { [ index ]: [] } ),
-							doingTermsFetch: false,
-						} );
+						setState( { errorMessage: error.message } );
 					} );
 				} );
+
+				setState( { doingTermsFetch: false } );
 			}
 
 			if ( postID && '' !== customPostType && doRequest ) {
@@ -209,7 +204,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 					triggerRefresh: false,
 				} );
 
-				let data = {
+				let fetchData = {
 					per_page: itemCount,
 					order: order,
 					orderby: orderBy,
@@ -219,7 +214,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 
 				if ( customTaxonomy ) {
 					customTaxonomy.forEach( ( taxonomy ) => {
-						if ( !taxonomy.slug || 0 > taxonomy.terms.length ) {
+						if ( !taxonomy.slug || !taxonomy.terms || 0 > taxonomy.terms.length ) {
 							return;
 						}
 
@@ -228,13 +223,13 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 						if ( 'AND' === taxonomy.operator ) {
 							// This space intentionally left blank...
 						} else {
-							data[ termSlug ] = taxonomy.terms.join( ',' );
+							fetchData[ termSlug ] = taxonomy.terms.join( ',' );
 						}
 					} );
 				}
 
 				apiFetch( {
-					path: addQueryArgs( '/wp/v2/' + restSlug, data ),
+					path: addQueryArgs( '/wp/v2/' + restSlug, fetchData ),
 				} ).then( data => {
 					setState( {
 						latestPosts: data,
@@ -428,7 +423,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							onChange={ ( value ) => {
 								if ( '' === value ) {
 									if ( 1 === customTaxonomy.length ) {
-										setAttributes( { customTaxonomy: undefined } );
+										setAttributes( { customTaxonomy: [] } );
 									} else {
 										customTaxonomy.splice( index, 1 );
 

--- a/src/index.js
+++ b/src/index.js
@@ -354,13 +354,44 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 		};
 
 		const updatedCustomTaxonomy = ( index, property, value ) => {
-			return Object.values( {
+			let customTaxonomyUpdates = Object.values( {
 				...customTaxonomy,
 				[ index ]: {
 					...customTaxonomy[ index ],
 					[ property ]: value,
 				}
 			} );
+
+			// Resets the `terms` and `operator` properties when the slug is changed.
+			if ( 'slug' === property && value !== customTaxonomy[ index ].slug ) {
+				customTaxonomyUpdates = Object.values( {
+					...customTaxonomyUpdates,
+					[ index ]: {
+						...customTaxonomyUpdates[ index ],
+						terms: [],
+						operator: undefined,
+					}
+				} );
+			}
+
+			// Handles changes to the `operator` property when terms are changed.
+			if ( 'terms' === property ) {
+				const operatorValue = ( !customTaxonomy[ index ].operator && 1 < value.length )
+					? 'IN'
+					: ( 1 < value.length )
+						? customTaxonomy[ index ].operator
+						: undefined;
+
+				customTaxonomyUpdates = Object.values( {
+					...customTaxonomyUpdates,
+					[ index ]: {
+						...customTaxonomyUpdates[ index ],
+						operator: operatorValue,
+					}
+				} );
+			}
+
+			return customTaxonomyUpdates;
 		}
 
 		const taxonomySetting = ( taxonomy, index ) => {

--- a/src/index.js
+++ b/src/index.js
@@ -226,8 +226,6 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 					}
 				}
 
-				console.log( addQueryArgs( '/lcp/v1/posts/', fetchData ) );
-
 				apiFetch( {
 					path: addQueryArgs( '/lcp/v1/posts/', fetchData ),
 				} ).then( data => {


### PR DESCRIPTION
Initial work to for https://github.com/happyprime/latest-custom-posts/issues/10.

Not 100% there just yet, but usable to some extent :)

I don't know if `'relation' => 'AND'` queries or use of the `operator` argument for finding posts with all the given terms are supported by WPAPI, so accurate results won't be reflected in the editor if those are used. The front end should work as expected, though. Other than that, there are very likely a few other wrinkles on the editor side that need to be ironed out.