### PR TITLE
Add content options

### DIFF
--- a/includes/block.php
+++ b/includes/block.php
@@ -196,13 +196,6 @@ function render_block( $attributes ) {
 	$args       = build_query_args( $attributes );
 	$posts      = get_posts( $args );
 
-	// Render nothing if no posts are available.
-	if ( empty( $posts ) ) {
-		return '';
-	}
-
-	ob_start();
-
 	$container_class = 'wp-block-latest-posts wp-block-latest-posts__list happyprime-latest-custom-posts';
 
 	if ( isset( $attributes['align'] ) ) {
@@ -224,6 +217,23 @@ function render_block( $attributes ) {
 	if ( isset( $attributes['className'] ) ) {
 		$container_class .= ' ' . $attributes['className'];
 	}
+
+	// Render "No current items" message if no posts are available.
+	if ( empty( $posts ) ) {
+		$container_class .= ' happyprime-latest-custom-posts_no-posts';
+
+		ob_start();
+		?>
+		<ul class="<?php echo esc_attr( $container_class ); ?>">
+			<li>No current items</li>
+		</ul>
+		<?php
+		$html = ob_get_clean();
+
+		return $html;
+	}
+
+	ob_start();
 
 	?>
 	<ul class="<?php echo esc_attr( $container_class ); ?>">

--- a/includes/block.php
+++ b/includes/block.php
@@ -380,7 +380,8 @@ function rest_response( $request ) {
 }
 
 /**
- * .
+ * Adds image size data to the editor settings so that it is immediately
+ * available to the block.
  *
  * @param array $editor_settings Editor settings.
  *

--- a/src/index.js
+++ b/src/index.js
@@ -522,13 +522,8 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 								}
 							} }
 						/>
-						<ToggleControl
-							label={ __( 'Display post date' ) }
-							checked={ displayPostDate }
-							onChange={ ( value ) => setAttributes( { displayPostDate: value } ) }
-						/>
-						<TextControl
-							label="Number of items"
+						<RangeControl
+							label={ __( 'Number of items' ) }
 							value={ itemCount }
 							onChange={ ( value ) => {
 								setAttributes( { itemCount: Number( value ) } );

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,6 @@ const {
 const {
 	PanelBody,
 	SelectControl,
-	TextControl,
 	ToggleControl,
 	Toolbar,
 	RangeControl,
@@ -239,6 +238,8 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 			displayPostContent,
 			postContent,
 			excerptLength,
+			displayImage,
+			imageSize,
 		} = attributes;
 
 		const taxonomies = ( 0 < attributes.taxonomies.length )
@@ -334,6 +335,9 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 						<time dateTime={ format( 'c', post.date_gmt ) } className="wp-block-latest-posts__post-date">
 							{ dateI18n( __experimentalGetSettings().formats.date, post.date_gmt ) }
 						</time>
+					}
+					{ displayImage && post.image[ imageSize ] &&
+						<img src={ post.image[ imageSize ] } />
 					}
 					{ displayPostContent && postContent === 'excerpt' &&
 						<div className="wp-block-latest-posts__post-excerpt">
@@ -649,7 +653,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 						/>
 						{ displayPostContent &&
 							<RadioControl
-								label={ __( 'Show:' ) }
+								label={ __( 'Show' ) }
 								selected={ postContent }
 								options={ [
 									{ label: __( 'Excerpt' ), value: 'excerpt' },
@@ -665,6 +669,19 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 								onChange={ ( value ) => setAttributes( { excerptLength: value } ) }
 								min={ 10 }
 								max={ 100 }
+							/>
+						}
+						<ToggleControl
+							label={ __( 'Display featured image' ) }
+							checked={ displayImage }
+							onChange={ ( value ) => setAttributes( { displayImage: value } ) }
+						/>
+						{ displayImage &&
+							<SelectControl
+								label={ __( 'Image size' ) }
+								selected={ imageSize }
+								options={ select( 'core/editor' ).getEditorSettings().lcpImageSizeOptions }
+								onChange={ ( value ) => setAttributes( { imageSize: value } ) }
 							/>
 						}
 					</PanelBody>

--- a/src/index.js
+++ b/src/index.js
@@ -224,6 +224,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 			setAttributes,
 			setState,
 			className,
+			doingLatestPostsFetch,
 		} = props;
 
 		const {
@@ -704,9 +705,11 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 					<p className="happyprime-block-latest-custom-posts_error">{
 						( errorMessage )
 							? errorMessage
-							: ( customPostType )
-								? <Spinner />
-								: 'Select a post type in this block\'s settings.'
+							: ( !customPostType )
+								? __( 'Select a post type in this block\'s settings.' )
+								: ( doingLatestPostsFetch )
+									? <Spinner />
+									: __( 'No current items' )
 					}</p>
 				) }
 			</Fragment>

--- a/src/index.js
+++ b/src/index.js
@@ -474,7 +474,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 			<Fragment>
 				<InspectorControls>
 					<PanelBody
-						title={ __( 'Settings' ) }
+						title={ __( 'Sorting and Filtering' ) }
 						className="panelbody-custom-latest-posts"
 					>
 						<SelectControl
@@ -606,6 +606,16 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 								required
 							/>
 						}
+					</PanelBody>
+					<PanelBody
+						title={ __( 'Post Content Settings' ) }
+						className="panelbody-custom-latest-posts"
+					>
+						<ToggleControl
+							label={ __( 'Display post date' ) }
+							checked={ displayPostDate }
+							onChange={ ( value ) => setAttributes( { displayPostDate: value } ) }
+						/>
 					</PanelBody>
 				</InspectorControls>
 				<BlockControls>

--- a/src/index.js
+++ b/src/index.js
@@ -262,7 +262,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 		let currentTaxonomies = select( 'core' ).getTaxonomies();
 		let postTypeOptions   = [];
 		let taxonomySlugs     = [];
-		let taxonomyOptions   = [ { label: 'None', value: '' } ];
+		let taxonomyOptions   = [ { label: __( 'None' ), value: '' } ];
 
 		if ( null === currentTypes ) {
 			currentTypes = [];
@@ -405,7 +405,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 					) }
 					<div className="happyprime-block-latest-custom-posts_taxonomy-setting">
 						<SelectControl
-							label="Taxonomy"
+							label={ __( 'Taxonomy' ) }
 							value={ ( taxonomy.slug ) ? taxonomy.slug : '' }
 							options={ taxonomyOptions }
 							onChange={ ( value ) => {
@@ -434,8 +434,8 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 						{ ( taxonomy.slug !== '' && terms[ index ] && 0 < terms[ index ].length ) && (
 							<SelectControl
 								multiple
-								label="Term(s)"
-								help="Ctrl/Cmd + click to select multiple terms"
+								label={ __( 'Term(s)' ) }
+								help={ __( 'Ctrl/Cmd + click to select multiple terms' ) }
 								value={ taxonomy.terms }
 								options={ terms[ index ] }
 								onChange={ ( value ) => {
@@ -450,11 +450,11 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 						{ ( taxonomy.terms && 1 < taxonomy.terms.length ) && (
 							<RadioControl
 								value={ taxonomy.operator }
-								label="Show posts with:"
+								label={ __( 'Show posts with:' ) }
 								selected={ taxonomy.operator }
 								options={ [
-									{ label: 'Any selected terms', value: 'IN' },
-									{ label: 'All selected terms', value: 'AND' },
+									{ label: __( 'Any selected terms' ), value: 'IN' },
+									{ label: __( 'All selected terms' ), value: 'AND' },
 								] }
 								onChange={ ( value ) => {
 									setAttributes( { taxonomies: updatedTaxonomies( index, 'operator', value ) } );
@@ -532,9 +532,11 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 									latestPosts: []
 								} );
 							} }
+							min={ 1 }
+							max={ 100 }
 						/>
 						<SelectControl
-							label="Post Type"
+							label={ __( 'Post Type' ) }
 							value={ customPostType }
 							options={ postTypeOptions }
 							onChange={ ( customPostType ) => {

--- a/src/index.js
+++ b/src/index.js
@@ -236,6 +236,9 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 			displayPostDate,
 			postLayout,
 			columns,
+			displayPostContent,
+			postContent,
+			excerptLength,
 		} = attributes;
 
 		const taxonomies = ( 0 < attributes.taxonomies.length )
@@ -310,6 +313,12 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 		const displayListItem = ( post ) => {
 			const titleTrimmed = post.title.trim();
 
+			const excerptElement = document.createElement( 'div' );
+
+			excerptElement.innerHTML = post.excerpt;
+
+			const excerpt = excerptElement.textContent || excerptElement.innerText || '';
+
 			return (
 				<li>
 					<a href={ post.link } target="_blank" rel="noreferrer noopener">
@@ -325,6 +334,26 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 						<time dateTime={ format( 'c', post.date_gmt ) } className="wp-block-latest-posts__post-date">
 							{ dateI18n( __experimentalGetSettings().formats.date, post.date_gmt ) }
 						</time>
+					}
+					{ displayPostContent && postContent === 'excerpt' &&
+						<div className="wp-block-latest-posts__post-excerpt">
+							<RawHTML
+								key="html"
+							>
+								{ excerptLength < excerpt.trim().split( ' ' ).length ?
+									excerpt.trim().split( ' ', excerptLength ).join( ' ' ) + '…' :
+									excerpt.trim().split( ' ', excerptLength ).join( ' ' ) }
+							</RawHTML>
+						</div>
+					}
+					{ displayPostContent && postContent === 'full_post' &&
+						<div className="wp-block-latest-posts__post-full-content">
+							<RawHTML
+								key="html"
+							>
+								{ post.content.trim() }
+							</RawHTML>
+						</div>
 					}
 				</li>
 			);
@@ -613,6 +642,31 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 							checked={ displayPostDate }
 							onChange={ ( value ) => setAttributes( { displayPostDate: value } ) }
 						/>
+						<ToggleControl
+							label={ __( 'Display post content' ) }
+							checked={ displayPostContent }
+							onChange={ ( value ) => setAttributes( { displayPostContent: value } ) }
+						/>
+						{ displayPostContent &&
+							<RadioControl
+								label={ __( 'Show:' ) }
+								selected={ postContent }
+								options={ [
+									{ label: __( 'Excerpt' ), value: 'excerpt' },
+									{ label: __( 'Full Post' ), value: 'full_post' },
+								] }
+								onChange={ ( value ) => setAttributes( { postContent: value } ) }
+							/>
+						}
+						{ displayPostContent && postContent === 'excerpt' &&
+							<RangeControl
+								label={ __( 'Max number of words in excerpt' ) }
+								value={ excerptLength }
+								onChange={ ( value ) => setAttributes( { excerptLength: value } ) }
+								min={ 10 }
+								max={ 100 }
+							/>
+						}
 					</PanelBody>
 				</InspectorControls>
 				<BlockControls>


### PR DESCRIPTION
* Integrates the upstream options for displaying post excerpts or full content;
* changes the input for the "Number of items" option to a `rangeControl`;
* adds an option for displaying featured images at any available size;
* introduces a "Post Content" panel for housing the above options and the "Display post date" option;
* updates labels and help text to translation strings throughout;
* adds "No current items" text for cases when no posts are found.