### PR TITLE
Add a random order option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -542,6 +542,11 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 									label: __( 'Z → A' ),
 									value: 'title/desc',
 								},
+								{
+									/* translators: label for displaying random posts */
+									label: __( 'Random' ),
+									value: 'rand/desc',
+								},
 							] }
 							onChange={ ( value ) => {
 								const [ newOrderBy, newOrder ] = value.split( '/' );

--- a/src/index.js
+++ b/src/index.js
@@ -598,7 +598,7 @@ registerBlockType( 'happyprime/latest-custom-posts', {
 								} );
 							} }
 						/>
-						{ lcpbStickyPostSupport.includes( customPostType.split( ',' )[0] ) &&
+						{ lcpbStickyPostSupport.includes( customPostType.split( ',' )[0] ) && 'date' === orderBy &&
 							<ToggleControl
 								label={ __( 'Show sticky posts at the start of the set' ) }
 								checked={ stickyPosts }


### PR DESCRIPTION
* Add an option for displaying random posts.
* Display sticky posts toggle only if a `date`-based Order by option is selected.
  * Sticky posts are only handled for the `date` orderby value, so we shouldn't display the toggle for other options.