### PR TITLE
Introduce filters to allow customizations to individual item markup

### DIFF
--- a/includes/block.php
+++ b/includes/block.php
@@ -468,6 +468,8 @@ function rest_response( $request ) {
 				'image'    => $image_sizes,
 			);
 
+			$post = apply_filters( 'content_aggregator_block_endpoint_post_data', $post, get_the_ID() );
+
 			$posts[] = $post;
 		}
 		wp_reset_postdata();

--- a/includes/block.php
+++ b/includes/block.php
@@ -294,40 +294,8 @@ function render_block( $attributes ) {
 			while ( $query->have_posts() ) {
 				$query->the_post();
 				$post = get_post( get_the_ID() );
-				?>
-				<li <?php post_class( 'cab-item' ); ?>>
-					<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
-					<?php
-					if ( isset( $attributes['displayPostDate'] ) && $attributes['displayPostDate'] ) {
-						?>
-						<time datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>" class="wp-block-latest-posts__post-date"><?php echo esc_html( get_the_date( '' ) ); ?></time>
-						<?php
-					}
-					if ( isset( $attributes['displayImage'] ) && $attributes['displayImage'] && has_post_thumbnail() ) {
-						$image_id = get_post_thumbnail_id();
-						echo wp_get_attachment_image( $image_id, $attributes['imageSize'], false );
-					}
-					if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent'] && isset( $attributes['postContent'] ) ) {
-						if ( 'excerpt' === $attributes['postContent'] ) {
-							$post_excerpt    = ( $post->post_excerpt ) ? $post->post_excerpt : $post->post_content;
-							$trimmed_excerpt = esc_html( wp_trim_words( $post_excerpt, $attributes['excerptLength'], '&hellip;' ) );
-							?>
-							<div class="wp-block-latest-posts__post-excerpt">
-								<?php echo wp_kses_post( $trimmed_excerpt ); ?>
-							</div>
-							<?php
-						}
-						if ( 'full_post' === $attributes['postContent'] ) {
-							?>
-							<div class="wp-block-latest-posts__post-full-content">
-								<?php echo wp_kses_post( html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) ) ); ?>
-							</div>
-							<?php
-						}
-					}
-					?>
-				</li>
-				<?php
+
+				render_item( $post, $attributes );
 			}
 			?>
 		</ul>
@@ -347,6 +315,54 @@ function render_block( $attributes ) {
 	}
 
 	return $html;
+}
+
+/**
+ * Render the markup for an individual post item.
+ *
+ * @param WP_Post $post       The post.
+ * @param array   $attributes Attys.
+ */
+function render_item( $post, $attributes ) {
+	ob_start();
+	?>
+	<li <?php post_class( 'cab-item' ); ?>>
+		<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+		<?php
+		if ( isset( $attributes['displayPostDate'] ) && $attributes['displayPostDate'] ) {
+			?>
+			<time datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>" class="wp-block-latest-posts__post-date"><?php echo esc_html( get_the_date( '' ) ); ?></time>
+			<?php
+		}
+		if ( isset( $attributes['displayImage'] ) && $attributes['displayImage'] && has_post_thumbnail() ) {
+			$image_id = get_post_thumbnail_id();
+			echo wp_get_attachment_image( $image_id, $attributes['imageSize'], false );
+		}
+		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent'] && isset( $attributes['postContent'] ) ) {
+			if ( 'excerpt' === $attributes['postContent'] ) {
+				$post_excerpt    = ( $post->post_excerpt ) ? $post->post_excerpt : $post->post_content;
+				$trimmed_excerpt = esc_html( wp_trim_words( $post_excerpt, $attributes['excerptLength'], '&hellip;' ) );
+				?>
+				<div class="wp-block-latest-posts__post-excerpt">
+					<?php echo wp_kses_post( $trimmed_excerpt ); ?>
+				</div>
+				<?php
+			}
+			if ( 'full_post' === $attributes['postContent'] ) {
+				?>
+				<div class="wp-block-latest-posts__post-full-content">
+					<?php echo wp_kses_post( html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) ) ); ?>
+				</div>
+				<?php
+			}
+		}
+		?>
+	</li>
+	<?php
+	$html      = ob_get_clean();
+	$item_html = apply_filters( 'content_aggregator_block_item', $html, $post, $attributes );
+
+	echo wp_kses_post( $item_html );
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,10 @@ const {
 	apiFetch,
 } = wp;
 
+const {
+	applyFilters,
+} = wp.hooks;
+
 const MAX_POSTS_COLUMNS = 6;
 
 const TAXONOMY_SETTING = {
@@ -329,7 +333,7 @@ registerBlockType( 'happyprime/content-aggregator', {
 
 			const excerpt = excerptElement.textContent || excerptElement.innerText || '';
 
-			return (
+			const item = (
 				<li>
 					<a href={ post.link } target="_blank" rel="noreferrer noopener">
 						{ titleTrimmed ? (
@@ -370,6 +374,8 @@ registerBlockType( 'happyprime/content-aggregator', {
 					}
 				</li>
 			);
+
+			return applyFilters( 'contentAggregatorBlock.itemHTML', item, post, attributes )
 		};
 
 		const updatedTaxonomies = ( index, property, value ) => {


### PR DESCRIPTION
* Add the `content_aggregator_block_item` filter hook for adjusting output on the front-end.
* Add the `contentAggregatorBlock.itemHTML` filter for adjusting output in the block editor.
* Add the `content_aggregator_block_endpoint_post_data` filter hook for adjusting post data returned by the REST API endpoint.