### PR TITLE
Fix taxonomy term select element height

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -11,6 +11,15 @@
 	margin-bottom: 0;
 }
 
+.happyprime-block-content-aggregator-block_taxonomy .happyprime-block-content-aggregator-block_taxonomy-setting-wrapper select[multiple] {
+	height: auto;
+	padding-right: 8px;
+}
+
+.happyprime-block-content-aggregator-block_taxonomy .happyprime-block-content-aggregator-block_taxonomy-setting-wrapper select[multiple] + .components-input-control__suffix {
+	display: none;
+}
+
 .happyprime-block-content-aggregator-block_remove-taxonomy-setting {
 	border-radius: 50%;
 	left: 6px;

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ const {
 	RadioControl,
 	IconButton,
 	Spinner,
+	Disabled,
 } = wp.components;
 
 const {
@@ -335,15 +336,17 @@ registerBlockType( 'happyprime/content-aggregator', {
 
 			const item = (
 				<li>
-					<a href={ post.link } target="_blank" rel="noreferrer noopener">
-						{ titleTrimmed ? (
-							<RawHTML>
-								{ titleTrimmed }
-							</RawHTML>
-						) :
-							__( '(Untitled)' )
-						}
-					</a>
+					<Disabled>
+						<a href={ post.link } target="_blank" rel="noreferrer noopener">
+							{ titleTrimmed ? (
+								<RawHTML>
+									{ titleTrimmed }
+								</RawHTML>
+							) :
+								__( '(Untitled)' )
+							}
+						</a>
+					</Disabled>
 					{ displayPostDate && post.date_gmt &&
 						<time dateTime={ format( 'c', post.date_gmt ) } className="wp-block-latest-posts__post-date">
 							{ dateI18n( __experimentalGetSettings().formats.date, post.date_gmt ) }

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,10 @@ const {
 	applyFilters,
 } = wp.hooks;
 
+const {
+	decodeEntities,
+} = wp.htmlEntities;
+
 const MAX_POSTS_COLUMNS = 6;
 
 const TAXONOMY_SETTING = {
@@ -165,7 +169,7 @@ registerBlockType( 'happyprime/content-aggregator', {
 					} ).then( data => {
 						const termData = data.map( term => {
 							return {
-								label: term.name,
+								label: decodeEntities( term.name ),
 								value: term.id,
 							}
 						} );


### PR DESCRIPTION
* Update styles for term select element to remove hard height limit and hide some chrome not appropriate for `multi` select.
* Wrap anchors in the Disabled component.
  * I got tired of accidentally clicking links and being taken away from the Edit page.
* Decode entities in term names (so things like ampersands display as `&` instead of `&amp;`, etc.).