### PR TITLE
Fix REST route registration

### DIFF
--- a/includes/block.php
+++ b/includes/block.php
@@ -483,13 +483,18 @@ function register_meta_endpoint() {
 }
 
 /**
- * Make sure only users who can edit posts can access this REST API route.
+ * Return the meta keys registered for the provided post type.
+ *
+ * @param \WP_Request $request The incoming REST API request object.
+ *
+ * @return array Posts found using the provided parameters.
  */
-function meta_rest_permission() {
-	if ( ! current_user_can( 'edit-posts' ) ) {
-		return new WP_Error( 'rest_forbidden', esc_html__( 'Sorry, you are not allowed to view this data.' ), array( 'status' => 401 ) );
-	}
-	return true;
+function meta_rest_response( $request ) {
+	global $wp_meta_keys;
+
+	$subtype = $request->get_param( 'post_type' ) ?? 'post';
+
+	return array_keys( $wp_meta_keys['post'][ $subtype ] );
 }
 
 /**

--- a/includes/block.php
+++ b/includes/block.php
@@ -477,7 +477,7 @@ function register_meta_endpoint() {
 		array(
 			'methods'             => 'GET',
 			'callback'            => __NAMESPACE__ . '\meta_rest_response',
-			'permission_callback' => '__return_true',
+			'permission_callback' => __NAMESPACE__ . '\meta_rest_permission',
 		)
 	);
 }
@@ -495,6 +495,16 @@ function meta_rest_response( $request ) {
 	$subtype = $request->get_param( 'post_type' ) ?? 'post';
 
 	return array_keys( $wp_meta_keys['post'][ $subtype ] );
+}
+
+/**
+ * Make sure only users who can edit posts can access this REST API route.
+ */
+function meta_rest_permission() {
+	if ( ! current_user_can( 'edit-posts' ) ) {
+		return new WP_Error( 'rest_forbidden', esc_html__( 'Sorry, you are not allowed to view this data.' ), array( 'status' => 401 ) );
+	}
+	return true;
 }
 
 /**

--- a/includes/block.php
+++ b/includes/block.php
@@ -477,24 +477,9 @@ function register_meta_endpoint() {
 		array(
 			'methods'             => 'GET',
 			'callback'            => __NAMESPACE__ . '\meta_rest_response',
-			'permission_callback' => __NAMESPACE__ . '\meta_rest_permission',
+			'permission_callback' => '__return_true',
 		)
 	);
-}
-
-/**
- * Return the meta keys registered for the provided post type.
- *
- * @param \WP_Request $request The incoming REST API request object.
- *
- * @return array Posts found using the provided parameters.
- */
-function meta_rest_response( $request ) {
-	global $wp_meta_keys;
-
-	$subtype = $request->get_param( 'post_type' ) ?? 'post';
-
-	return array_keys( $wp_meta_keys['post'][ $subtype ] );
 }
 
 /**

--- a/includes/block.php
+++ b/includes/block.php
@@ -367,8 +367,9 @@ function register_posts_endpoint() {
 		'content-aggregator-block/v1',
 		'posts',
 		array(
-			'methods'  => 'GET',
-			'callback' => __NAMESPACE__ . '\posts_rest_response',
+			'methods'             => 'GET',
+			'callback'            => __NAMESPACE__ . '\posts_rest_response',
+			'permission_callback' => '__return_true',
 		)
 	);
 }
@@ -474,8 +475,9 @@ function register_meta_endpoint() {
 		'content-aggregator-block/v1',
 		'meta',
 		array(
-			'methods'  => 'GET',
-			'callback' => __NAMESPACE__ . '\meta_rest_response',
+			'methods'             => 'GET',
+			'callback'            => __NAMESPACE__ . '\meta_rest_response',
+			'permission_callback' => '__return_true',
 		)
 	);
 }


### PR DESCRIPTION
- Add a newly-required parameter to the two calls to `register_rest_route()`: `permission_callback`.
- Both the Post and the Meta route are set to `__return_true`. At first I tried setting Meta to ensure the current user can `edit-posts`, but that was causing 500 errors in the Editor.

Fixes #64 