### PR TITLE
Add empty postcss config to avoid using parent directories'

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
There's probably a nicer way to do this, but a `postcss.config.js` file two directories up from where I had this plugin was causing an issue with stylelint.