### PR TITLE
Add a pre filter for rendering item HTML

### DIFF
--- a/includes/block.php
+++ b/includes/block.php
@@ -277,6 +277,13 @@ function render( $attributes ) {
  * @param array   $attributes The block attributes.
  */
 function render_item( $post, $attributes ) {
+	$pre_render_html = apply_filters( 'content_aggregator_block_pre_render_item', false, $post, $attributes );
+
+	if ( false !== $pre_render_html ) {
+		echo $pre_render_html;
+		return;
+	}
+
 	ob_start();
 	?>
 	<li <?php post_class( 'cab-item' ); ?>>


### PR DESCRIPTION
This allows a plugin or theme to hijack the display of an item's HTML without doing any additional processing and without requiring that it go through `wp_kses()`.